### PR TITLE
ARM64 Suppport + Bump Obsidian to 1.0.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: '/' # Location of package manifests
     schedule:
       interval: 'daily'
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+        interval: "daily"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,17 +56,21 @@ jobs:
         with:
           context: .
           file: dockerfile.amd64
-          platforms: linux/amd64 #,linux/arm64,linux/arm/v7,linux/arm/v6, linux/386, linux/ppc64le,linux/s390x
+          platforms: linux/amd64
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:latest
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:buildcache_amd64
+          cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:buildcache_amd64,mode=max
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v3
         with:
           context: .
           file: dockerfile.arm64
-          platforms: linux/arm64 #,linux/arm64,linux/arm/v7,linux/arm/v6, linux/386, linux/ppc64le,linux/s390x
+          platforms: linux/arm64
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:arm64
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:buildcache_arm64
+          cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:buildcache_arm64,mode=max          

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - latest
+      - main
     paths-ignore:
       - 'README.MD'
       - '.github'

--- a/.github/workflows/justsky.yml
+++ b/.github/workflows/justsky.yml
@@ -57,7 +57,7 @@ jobs:
           file: dockerfile.amd64
           platforms: linux/amd64 #,linux/arm64,linux/arm/v7,linux/arm/v6, linux/386, linux/ppc64le,linux/s390x
           push: true
-          tags: latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:latest
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Build and push Docker images
@@ -67,5 +67,5 @@ jobs:
           file: dockerfile.arm64
           platforms: linux/arm64 #,linux/arm64,linux/arm/v7,linux/arm/v6, linux/386, linux/ppc64le,linux/s390x
           push: true
-          tags: arm64
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:arm64
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/justsky.yml
+++ b/.github/workflows/justsky.yml
@@ -1,0 +1,71 @@
+name: Docker
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 1"
+  push:
+    branches:
+      - latest
+    paths-ignore:
+      - 'README.MD'
+      - '.github'
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+#      - name: Log in to the Container registry
+#        uses: docker/login-action@v2
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GIT_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker.amd64
+          platforms: linux/amd64 #,linux/arm64,linux/arm/v7,linux/arm/v6, linux/386, linux/ppc64le,linux/s390x
+          push: true
+          tags: latest
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker.arm64
+          platforms: linux/arm64 #,linux/arm64,linux/arm/v7,linux/arm/v6, linux/386, linux/ppc64le,linux/s390x
+          push: true
+          tags: arm64
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/justsky.yml
+++ b/.github/workflows/justsky.yml
@@ -54,7 +54,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: docker.amd64
+          file: dockerfile.amd64
           platforms: linux/amd64 #,linux/arm64,linux/arm/v7,linux/arm/v6, linux/386, linux/ppc64le,linux/s390x
           push: true
           tags: latest
@@ -64,7 +64,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: docker.arm64
+          file: dockerfile.arm64
           platforms: linux/arm64 #,linux/arm64,linux/arm/v7,linux/arm/v6, linux/386, linux/ppc64le,linux/s390x
           push: true
           tags: arm64

--- a/dockerfile.amd64
+++ b/dockerfile.amd64
@@ -1,0 +1,49 @@
+FROM ghcr.io/linuxserver/baseimage-rdesktop-web:focal
+RUN \
+    echo "**** install packages ****" && \
+        # Update and install extra packages.
+        apt-get update && \
+        apt-get install -y --no-install-recommends \
+            # Packages needed to download and extract obsidian.
+            curl \
+            libnss3 \
+            # Install Chrome dependencies.
+            dbus-x11 \
+            uuid-runtime && \
+    echo "**** cleanup ****" && \
+        apt-get autoclean && \
+        rm -rf \
+        /var/lib/apt/lists/* \
+        /var/tmp/* \
+        /tmp/*
+
+# set version label
+ARG OBSIDIAN_VERSION=1.0.3
+
+RUN \
+    echo "**** download obsidian ****" && \
+        curl \
+        https://github.com/obsidianmd/obsidian-releases/releases/download/v$OBSIDIAN_VERSION/Obsidian-$OBSIDIAN_VERSION.AppImage \
+        -L \
+        -o obsidian.AppImage
+
+RUN \
+    echo "**** extract obsidian ****" && \
+        chmod +x /obsidian.AppImage && \
+        /obsidian.AppImage --appimage-extract
+
+ENV \
+    CUSTOM_PORT="8080" \
+    GUIAUTOSTART="true" \
+    HOME="/vaults" \
+    TITLE="Obsidian v$OBSIDIAN_VERSION"
+
+# add local files
+COPY root/ /
+
+EXPOSE 8080
+EXPOSE 27123
+EXPOSE 27124
+VOLUME ["/config","/vaults"]
+
+

--- a/dockerfile.arm64
+++ b/dockerfile.arm64
@@ -19,12 +19,13 @@ RUN \
         /tmp/*
 
 # set version label
-ARG OBSIDIAN_VERSION=1.0.3-arm64
+ARG OBSIDIAN_VERSION=1.0.3
+ARG ARCH=arm64
 
 RUN \
     echo "**** download obsidian ****" && \
         curl \
-        https://github.com/obsidianmd/obsidian-releases/releases/download/v$OBSIDIAN_VERSION/Obsidian-$OBSIDIAN_VERSION.AppImage \
+        https://github.com/obsidianmd/obsidian-releases/releases/download/v$OBSIDIAN_VERSION/Obsidian-$OBSIDIAN_VERSION-$ARCH.AppImage \
         -L \
         -o obsidian.AppImage
 

--- a/dockerfile.arm64
+++ b/dockerfile.arm64
@@ -20,12 +20,11 @@ RUN \
 
 # set version label
 ARG OBSIDIAN_VERSION=1.0.3
-ARG ARCH=arm64
 
 RUN \
     echo "**** download obsidian ****" && \
         curl \
-        https://github.com/obsidianmd/obsidian-releases/releases/download/v$OBSIDIAN_VERSION/Obsidian-$OBSIDIAN_VERSION-$ARCH.AppImage \
+        https://github.com/obsidianmd/obsidian-releases/releases/download/v$OBSIDIAN_VERSION/Obsidian-1.0.3-arm64.AppImage \
         -L \
         -o obsidian.AppImage
 

--- a/dockerfile.arm64
+++ b/dockerfile.arm64
@@ -20,13 +20,12 @@ RUN \
 
 # set version label
 ARG OBSIDIAN_VERSION=1.0.3
+ARG ARCH=arm64
 
 RUN \
     echo "**** download obsidian ****" && \
         curl \
-        https://github.com/obsidianmd/obsidian-releases/releases/download/v$OBSIDIAN_VERSION/Obsidian-1.0.3-arm64.AppImage \
-        -L \
-        -o obsidian.AppImage
+        https://github.com/obsidianmd/obsidian-releases/releases/download/v$OBSIDIAN_VERSION/Obsidian-1.0.3-arm64.AppImage  -o obsidian.AppImage
 
 RUN \
     echo "**** extract obsidian ****" && \

--- a/dockerfile.arm64
+++ b/dockerfile.arm64
@@ -1,0 +1,50 @@
+FROM ghcr.io/linuxserver/baseimage-rdesktop-web:focal
+RUN \
+    echo "**** install packages ****" && \
+        # Update and install extra packages.
+        apt-get update && \
+        apt-get install -y --no-install-recommends \
+            # Packages needed to download and extract obsidian.
+            curl \
+            libnss3 \
+            zlib1g-dev \
+            # Install Chrome dependencies.
+            dbus-x11 \
+            uuid-runtime && \
+    echo "**** cleanup ****" && \
+        apt-get autoclean && \
+        rm -rf \
+        /var/lib/apt/lists/* \
+        /var/tmp/* \
+        /tmp/*
+
+# set version label
+ARG OBSIDIAN_VERSION=1.0.3-arm64
+
+RUN \
+    echo "**** download obsidian ****" && \
+        curl \
+        https://github.com/obsidianmd/obsidian-releases/releases/download/v$OBSIDIAN_VERSION/Obsidian-$OBSIDIAN_VERSION.AppImage \
+        -L \
+        -o obsidian.AppImage
+
+RUN \
+    echo "**** extract obsidian ****" && \
+        chmod +x /obsidian.AppImage && \
+        /obsidian.AppImage --appimage-extract
+
+ENV \
+    CUSTOM_PORT="8080" \
+    GUIAUTOSTART="true" \
+    HOME="/vaults" \
+    TITLE="Obsidian v$OBSIDIAN_VERSION"
+
+# add local files
+COPY root/ /
+
+EXPOSE 8080
+EXPOSE 27123
+EXPOSE 27124
+VOLUME ["/config","/vaults"]
+
+


### PR DESCRIPTION
- For the new GH action to work: 
  - Need to add `DOCKERHUB_USERNAME` & `DOCKERHUB_TOKEN` to publish image to Dockerhub
  - Need to uncomment Line 40 to 45, provide `GIT_TOKEN`  &   add ` ghcr.io/${{ github.repository }}` to line 49 of Github action to publish image to ghcr.io

### Fixing 
- #8 
- #10 

Dockerhub ref: https://hub.docker.com/r/justsky/obsidian-remote