### PR TITLE
include git in docker image for the very popular community plugin obsidian git

### DIFF
--- a/dockerfile.amd64
+++ b/dockerfile.amd64
@@ -4,6 +4,8 @@ RUN \
         # Update and install extra packages.
         apt-get update && \
         apt-get install -y --no-install-recommends \
+            # Explicitly install git. Issue #36
+            git \
             # Packages needed to download and extract obsidian.
             curl \
             libnss3 \

--- a/dockerfile.arm64
+++ b/dockerfile.arm64
@@ -4,6 +4,8 @@ RUN \
         # Update and install extra packages.
         apt-get update && \
         apt-get install -y --no-install-recommends \
+            # Explicitly install git. Issue #36
+            git \        
             # Packages needed to download and extract obsidian.
             curl \
             libnss3 \


### PR DESCRIPTION
Resolve out #36 by explicitly installing git as part of container creation.