### PR TITLE
Change base image to kasmvnc

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,11 +21,11 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H:%M:%S')"
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository_owner }}/obsidian-remote
           tags: |
@@ -35,17 +35,17 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           #file: ./Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: dockerfile.amd64
@@ -64,7 +64,7 @@ jobs:
           cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:buildcache_amd64,mode=max
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: dockerfile.arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,55 +1,36 @@
-FROM ghcr.io/linuxserver/baseimage-rdesktop-web:focal
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbullseye
 
-LABEL org.opencontainers.image.authors="github@sytone.com"
-LABEL org.opencontainers.image.source="https://github.com/sytone/obsidian-remote"
-LABEL org.opencontainers.image.title="Container hosted Obsidian MD"
-LABEL org.opencontainers.image.description="Hosted Obsidian instance allowing access via web browser"
+LABEL maintainer="github@sytone.com" \
+      org.opencontainers.image.authors="github@sytone.com" \
+      org.opencontainers.image.source="https://github.com/sytone/obsidian-remote" \
+      org.opencontainers.image.title="Container hosted Obsidian MD" \
+      org.opencontainers.image.description="Hosted Obsidian instance allowing access via web browser"
 
-RUN \
-    echo "**** install packages ****" && \
-        # Update and install extra packages.
-        apt-get update && \
-        apt-get install -y --no-install-recommends \
-            # Packages needed to download and extract obsidian.
-            curl \
-            libnss3 \
-            # Install Chrome dependencies.
-            dbus-x11 \
-            uuid-runtime && \
-    echo "**** cleanup ****" && \
-        apt-get autoclean && \
-        rm -rf \
-        /var/lib/apt/lists/* \
-        /var/tmp/* \
-        /tmp/*
+# Update and install extra packages.
+RUN echo "**** install packages ****" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends curl libgtk-3-0 libnotify4 libatspi2.0-0 libsecret-1-0 libnss3 desktop-file-utils && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
 
-# set version label
-ARG OBSIDIAN_VERSION=0.15.9
+# Set version label
+ARG OBSIDIAN_VERSION=1.2.8
 
-RUN \
-    echo "**** download obsidian ****" && \
-        curl \
-        https://github.com/obsidianmd/obsidian-releases/releases/download/v$OBSIDIAN_VERSION/Obsidian-$OBSIDIAN_VERSION.AppImage \
-        -L \
-        -o obsidian.AppImage
+# Download and install Obsidian
+RUN echo "**** download obsidian ****" && \
+    curl --location --output obsidian.deb "https://github.com/obsidianmd/obsidian-releases/releases/download/v${OBSIDIAN_VERSION}/obsidian_${OBSIDIAN_VERSION}_amd64.deb" && \
+    dpkg -i obsidian.deb
 
-RUN \
-    echo "**** extract obsidian ****" && \
-        chmod +x /obsidian.AppImage && \
-        /obsidian.AppImage --appimage-extract
+# Environment variables
+ENV CUSTOM_PORT="8080" \
+    CUSTOM_HTTPS_PORT="8443" \
+    CUSTOM_USER="" \
+    PASSWORD="" \
+    SUBFOLDER="" \
+    TITLE="Obsidian v${OBSIDIAN_VERSION}" \
+    FM_HOME="/vaults"
 
-ENV \
-    CUSTOM_PORT="8080" \
-    GUIAUTOSTART="true" \
-    HOME="/vaults" \
-    TITLE="Obsidian v$OBSIDIAN_VERSION"
-
-# add local files
+# Add local files
 COPY root/ /
 
-EXPOSE 8080
-EXPOSE 27123
-EXPOSE 27124
+EXPOSE 8080 8443
 VOLUME ["/config","/vaults"]
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,6 @@ COPY root/ /
 
 EXPOSE 8080 8443
 VOLUME ["/config","/vaults"]
+
+# Define a healthcheck
+HEALTHCHECK CMD curl --fail http://localhost:8080/ || exit 1

--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ docker run -d `
 
 | Port  | Description                             |
 | ----- | --------------------------------------- |
-| 8080  | Obsidian Web Interface                  |
-| 27123 | Local REST API Plugin HTTP Server Port  |
-| 27124 | Local REST API Plugin HTTPS Server Port |
+| 8080  | HTTP Obsidian Web Interface             |
+| 8443  | HTTPS Obsidian Web Interface            |
 
 ### Mapped Volumes
 
@@ -79,11 +78,17 @@ docker run -d `
 | TZ                   | Set the Time Zone for the container, should match your TZ. `Etc/UTC` by default. See [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for valid options.                              |
 | DOCKER_MODS          | Use to add mods to the container like git. E.g. `DOCKER_MODS=linuxserver/mods:universal-git` See [Docker Mods](https://github.com/linuxserver/docker-mods) for details.                                                             |
 | KEYBOARD             | Used to se the keyboard being used for input. E.g. `KEYBOARD=en-us-qwerty` or `KEYBOARD=de-de-qwertz` a list of other possible values (not tested) can be found at <https://github.com/linuxserver/docker-digikam#keyboard-layouts> |
+| CUSTOM_PORT          | Internal port the container listens on for http if it needs to be swapped from the default 3000.                                                                                                                                    |
+| CUSTOM_HTTPS_PORT    | Internal port the container listens on for https if it needs to be swapped from the default 3001.                                                                                                                                   |
+| CUSTOM_USER          | HTTP Basic auth username, abc is default.                                                                                                                                                                                           |
+| PASSWORD             | HTTP Basic auth password, abc is default. If unset there will be no auth                                                                                                                                                            |
+| SUBFOLDER            | Subfolder for the application if running a subfolder reverse proxy, need both slashes IE `/subfolder/`                                                                                                                              |
+| TITLE                | The page title displayed on the web browser, default "KasmVNC Client".                                                                                                                                                              |
+| FM_HOME              | This is the home directory (landing) for the file manager, default "/config".                                                                                                                                                       |
 
 ## Using Docker Compose
 
 ```YAML
-version: '3.8'
 services:
   obsidian:
     image: 'ghcr.io/sytone/obsidian-remote:latest'
@@ -91,6 +96,7 @@ services:
     restart: unless-stopped
     ports:
       - 8080:8080
+      - 8443:8443
     volumes:
       - /home/obsidian/vaults:/vaults
       - /home/obsidian/config:/config
@@ -99,6 +105,11 @@ services:
       - PGID=1000
       - TZ=America/Los_Angeles
       - DOCKER_MODS=linuxserver/mods:universal-git
+      - CUSTOM_PORT="8080"
+      - CUSTOM_HTTPS_PORT="8443" 
+      - CUSTOM_USER=""
+      - PASSWORD=""
+      - SUBFOLDER=""
 ```
 
 ## Enabling GIT for the obsidian-git plugin
@@ -213,7 +224,6 @@ Thanks to @fahrenhe1t for this example.
 If you install obsidian-remote in Docker, you can proxy it through [Nginx Proxy Manager](https://nginxproxymanager.com/) (NPM - running on the same Docker instance), and use an access list to provide user authentication. The obsidian-remote container would have to be on the same network as Nginx Proxy Manager. If you don't expose the IP external to the container, authentication would be forced through NPM:
 
 ```yaml
-version: '3.8'
 services:
   obsidian:
     image: 'ghcr.io/sytone/obsidian-remote:latest'

--- a/dockerfile.amd64
+++ b/dockerfile.amd64
@@ -28,3 +28,6 @@ COPY root/ /
 
 EXPOSE 8080 8443
 VOLUME ["/config","/vaults"]
+
+# Define a healthcheck
+HEALTHCHECK CMD curl --fail http://localhost:8080/ || exit 1

--- a/dockerfile.amd64
+++ b/dockerfile.amd64
@@ -1,51 +1,30 @@
-FROM ghcr.io/linuxserver/baseimage-rdesktop-web:focal
-RUN \
-    echo "**** install packages ****" && \
-        # Update and install extra packages.
-        apt-get update && \
-        apt-get install -y --no-install-recommends \
-            # Explicitly install git. Issue #36
-            git \
-            # Packages needed to download and extract obsidian.
-            curl \
-            libnss3 \
-            # Install Chrome dependencies.
-            dbus-x11 \
-            uuid-runtime && \
-    echo "**** cleanup ****" && \
-        apt-get autoclean && \
-        rm -rf \
-        /var/lib/apt/lists/* \
-        /var/tmp/* \
-        /tmp/*
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbullseye
 
-# set version label
-ARG OBSIDIAN_VERSION=1.1.9
+# Update and install extra packages.
+RUN echo "**** install packages ****" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends curl libgtk-3-0 libnotify4 libatspi2.0-0 libsecret-1-0 libnss3 desktop-file-utils && \
+    apt-get autoclean && rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
 
-RUN \
-    echo "**** download obsidian ****" && \
-        curl \
-        https://github.com/obsidianmd/obsidian-releases/releases/download/v$OBSIDIAN_VERSION/Obsidian-$OBSIDIAN_VERSION.AppImage \
-        -L \
-        -o obsidian.AppImage
+# Set version label
+ARG OBSIDIAN_VERSION=1.2.8
 
-RUN \
-    echo "**** extract obsidian ****" && \
-        chmod +x /obsidian.AppImage && \
-        /obsidian.AppImage --appimage-extract
+# Download and install Obsidian
+RUN echo "**** download obsidian ****" && \
+    curl --location --output obsidian.deb "https://github.com/obsidianmd/obsidian-releases/releases/download/v${OBSIDIAN_VERSION}/obsidian_${OBSIDIAN_VERSION}_amd64.deb" && \
+    dpkg -i obsidian.deb
 
-ENV \
-    CUSTOM_PORT="8080" \
-    GUIAUTOSTART="true" \
-    HOME="/vaults" \
-    TITLE="Obsidian v$OBSIDIAN_VERSION"
+# Environment variables
+ENV CUSTOM_PORT="8080" \
+    CUSTOM_HTTPS_PORT="8443" \
+    CUSTOM_USER="" \
+    PASSWORD="" \
+    SUBFOLDER="" \
+    TITLE="Obsidian v${OBSIDIAN_VERSION}" \
+    FM_HOME="/vaults"
 
-# add local files
+# Add local files
 COPY root/ /
 
-EXPOSE 8080
-EXPOSE 27123
-EXPOSE 27124
+EXPOSE 8080 8443
 VOLUME ["/config","/vaults"]
-
-

--- a/dockerfile.arm64
+++ b/dockerfile.arm64
@@ -1,51 +1,43 @@
-FROM ghcr.io/linuxserver/baseimage-rdesktop-web:focal
-RUN \
-    echo "**** install packages ****" && \
-        # Update and install extra packages.
-        apt-get update && \
-        apt-get install -y --no-install-recommends \
-            # Explicitly install git. Issue #36
-            git \        
-            # Packages needed to download and extract obsidian.
-            curl \
-            libnss3 \
-            zlib1g-dev \
-            # Install Chrome dependencies.
-            dbus-x11 \
-            uuid-runtime && \
-    echo "**** cleanup ****" && \
-        apt-get autoclean && \
-        rm -rf \
-        /var/lib/apt/lists/* \
-        /var/tmp/* \
-        /tmp/*
+FROM ghcr.io/linuxserver/baseimage-rdesktop-web:focal-20210824
 
-# set version label
-ARG OBSIDIAN_VERSION=1.1.9
+ARG OBSIDIAN_VERSION=1.2.8
 ARG ARCH=arm64
 
-RUN \
-    echo "**** download obsidian ****" && \
+# Update and install extra packages.
+RUN echo "**** install packages ****" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
         curl \
-        https://github.com/obsidianmd/obsidian-releases/releases/download/v$OBSIDIAN_VERSION/Obsidian-1.1.9-arm64.AppImage  -o obsidian.AppImage
+        libnss3 \
+        zlib1g-dev \
+        dbus-x11 \
+        uuid-runtime && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
 
-RUN \
-    echo "**** extract obsidian ****" && \
-        chmod +x /obsidian.AppImage && \
-        /obsidian.AppImage --appimage-extract
+# Download and install Obsidian
+RUN echo "**** download obsidian ****" && \
+    curl -L -o /obsidian.AppImage \
+        "https://github.com/obsidianmd/obsidian-releases/releases/download/v${OBSIDIAN_VERSION}/Obsidian-${OBSIDIAN_VERSION}-${ARCH}.AppImage" && \
+    chmod +x /obsidian.AppImage && \
+    /obsidian.AppImage --appimage-extract
 
-ENV \
-    CUSTOM_PORT="8080" \
-    GUIAUTOSTART="true" \
-    HOME="/vaults" \
-    TITLE="Obsidian v$OBSIDIAN_VERSION"
+# Environment variables
+ENV CUSTOM_PORT="8080" \
+    CUSTOM_HTTPS_PORT="8443" \
+    CUSTOM_USER="" \
+    PASSWORD="" \
+    SUBFOLDER="" \
+    TITLE="Obsidian v$OBSIDIAN_VERSION" \
+    FM_HOME="/vaults"
 
-# add local files
+# Add local files
 COPY root/ /
 
-EXPOSE 8080
-EXPOSE 27123
-EXPOSE 27124
+# Expose ports and volumes
+EXPOSE 8080 27123 27124
 VOLUME ["/config","/vaults"]
 
-
+# Define a healthcheck
+HEALTHCHECK CMD curl --fail http://localhost:8080/ || exit 1

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,1 +1,1 @@
-/squashfs-root/obsidian --no-sandbox --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer
+sudo /usr/bin/obsidian --no-sandbox

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
     <menu id="root-menu" label="MENU">
-        <item label="Obsidian" icon="/root/usr/share/icons/hicolor/48x48/apps/obsidian.png">
+        <item label="Obsidian" icon="/usr/share/icons/hicolor/48x48/apps/obsidian.png">
             <action name="Execute">
                 <command>sudo /usr/bin/obsidian --no-sandbox</command>
             </action>

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
     <menu id="root-menu" label="MENU">
-        <item label="Obsidian" icon="/squashfs-root/usr/share/icons/hicolor/48x48/apps/obsidian.png">
+        <item label="Obsidian" icon="/root/usr/share/icons/hicolor/48x48/apps/obsidian.png">
             <action name="Execute">
-                <command>/squashfs-root/obsidian --no-sandbox --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer</command>
+                <command>sudo /usr/bin/obsidian --no-sandbox</command>
             </action>
         </item>
         <item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm">

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -40,4 +40,4 @@ echo "********************************"
 chown -R abc:abc \
     /config \
     /vaults \
-    /squashfs-root
+    /root


### PR DESCRIPTION
Updated the base image as per #51 

Also took the liberty to update some dependencies and utilize/document some environment variables that might be useful for the selfhosters among us.

Summary of changes:
- Updated Obsidian to 1.2.8
- Dockerfiles have been modified slightly to follow best practices
- Added some ENV variables from Kasm VNC
- Updated README
- Removed arguments disabling hardware acceleration running Obsidian
- Applied dependabot changes

I tried to avoid using the `--no-sandbox` argument, but the seccomp security profile I created was insufficient to get rid of it still as of yet.