### PR TITLE
Debian Update to bookworm release & Nextcloud sync feature & Obisidan latest release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+#Set your Nextcloud credentials and informations
+#Please fill all the variables
+
+# Nextcloud Username
+NC_USER=
+# Nextcloud Password
+NC_PASS=
+# Nextcloud hostname e.g: nextcloud.myserver.net
+NC_HOST=
+# Folder path on your Nextcloud personal space e.g: /Obsidian
+NC_PATH=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbookworm
 
 LABEL maintainer="github@sytone.com" \
-      org.opencontainers.image.authors="drdada" \
-      org.opencontainers.image.source="https://github.com/drdada/obsidian-remote" \
+      org.opencontainers.image.authors="github@sytone.com" \
+      org.opencontainers.image.source="https://github.com/sytone/obsidian-remote" \
       org.opencontainers.image.title="Container hosted Obsidian MD" \
       org.opencontainers.image.description="Hosted Obsidian instance allowing access via web browser"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,24 @@
-FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbullseye
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbookworm
 
 LABEL maintainer="github@sytone.com" \
-      org.opencontainers.image.authors="github@sytone.com" \
-      org.opencontainers.image.source="https://github.com/sytone/obsidian-remote" \
+      org.opencontainers.image.authors="drdada" \
+      org.opencontainers.image.source="https://github.com/drdada/obsidian-remote" \
       org.opencontainers.image.title="Container hosted Obsidian MD" \
       org.opencontainers.image.description="Hosted Obsidian instance allowing access via web browser"
 
 # Update and install extra packages.
 RUN echo "**** install packages ****" && \
     apt-get update && \
-    apt-get install -y --no-install-recommends curl libgtk-3-0 libnotify4 libatspi2.0-0 libsecret-1-0 libnss3 desktop-file-utils fonts-noto-color-emoji git ssh-askpass && \
+    apt-get install -y --no-install-recommends curl nextcloud-desktop-cmd libgtk-3-0 libnotify4 libatspi2.0-0 libsecret-1-0 libnss3 desktop-file-utils fonts-noto-color-emoji git ssh-askpass && \
     apt-get autoclean && rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
 
 # Set version label
-ARG OBSIDIAN_VERSION=1.4.13
+ARG OBSIDIAN_REMOTE_RELEASE=1.0
 
 # Download and install Obsidian
 RUN echo "**** download obsidian ****" && \
-    curl --location --output obsidian.deb "https://github.com/obsidianmd/obsidian-releases/releases/download/v${OBSIDIAN_VERSION}/obsidian_${OBSIDIAN_VERSION}_amd64.deb" && \
+    file_url=$(curl -s "https://api.github.com/repos/obsidianmd/obsidian-releases/releases/latest" | grep "browser_download_url.*deb" | cut -d : -f 2,3 | tr -d \") && \
+    curl --location --output obsidian.deb $file_url && \
     dpkg -i obsidian.deb
 
 # Environment variables
@@ -26,7 +27,7 @@ ENV CUSTOM_PORT="8080" \
     CUSTOM_USER="" \
     PASSWORD="" \
     SUBFOLDER="" \
-    TITLE="Obsidian v${OBSIDIAN_VERSION}" \
+    TITLE="Obsidian Remote v${OBSIDIAN_REMOTE_RELEASE}" \
     FM_HOME="/vaults"
 
 # Add local files

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # obsidian-remote
 
-This docker image allows you to run [obsidian](https://obsidian.md/) in docker as a container and access it via your web browser.
+This docker image allows you to run the latest version of [obsidian](https://obsidian.md/) in docker as a container and access it via your web browser.
 
 Use `http://localhost:8080/` to access it locally, do not expose this to the web unless you secure it and know what you are doing!!
 
@@ -12,6 +12,7 @@ Use `http://localhost:8080/` to access it locally, do not expose this to the web
 - [Enabling GIT for the obsidian-git plugin](#enabling-git-for-the-obsidian-git-plugin)
   - [Docker CLI example](#docker-cli-example)
 - [Reloading Obsidan in the Browser](#reloading-obsidan-in-the-browser)
+- [Nextcloud](#nextcloud)
 - [Setting PUID and PGID](#setting-puid-and-pgid)
 - [Adding missing fonts](#adding-missing-fonts)
   - [Map font file using Docker CLI](#map-font-file-using-docker-cli)
@@ -85,6 +86,10 @@ docker run -d `
 | SUBFOLDER            | Subfolder for the application if running a subfolder reverse proxy, need both slashes IE `/subfolder/`                                                                                                                              |
 | TITLE                | The page title displayed on the web browser, default "KasmVNC Client".                                                                                                                                                              |
 | FM_HOME              | This is the home directory (landing) for the file manager, default "/config".                                                                                                                                                       |
+| NC_USER              | Username for Nextcloud                                                                                                                                                       |
+| NC_PASS              | Password for Nextcloud                                                                                                                                                       |
+| NC_HOST              | Domain name of your Nextcloud instance E.g. nextcloud.mydomain.net                                                                                                                                                       |
+| NC_PATH              | Path where you store your md file on Nextcloud E.g. /Obsidian                                                                                                                                                       |
 
 ## Using Docker Compose
 
@@ -132,6 +137,26 @@ docker run -d `
 If you make changes to plugins or do updates that need to have obsidian restarted, instead of having to stop and start the docker container you can just close the Obsidian UI and right click to show the menus and reopen it. Here is a short clip showing how to do it.
 
 ![Reloading Obsidian in the Browser](./assets/ReloadExample.gif)
+
+## Nextcloud
+
+If you wish to store your MD files on your nextcloud instance, you can trigger a sync script.
+
+Please copy the .env.example file
+
+```
+cp .env.example .env
+```
+
+Now edit your .env file and fill your Nextcloud credentials and informations.
+
+### Trigger Sync
+
+The synchronization with Nextcloud is not automated because Obsidian frequently performs file save, which could result in frequent and potentially unnecessary synchronizations. To avoid network overload and minimize unnecessary traffic, the synchronization with Nextcloud is left to the user's discretion and must be done manually.
+
+This approach allows the user to control when the synchronization should take place, choosing appropriate moments when your work are done.
+
+You can trigger sync via right cliking on the desktop and choosing **Nextcloud Sync**
 
 ## Setting PUID and PGID
 
@@ -183,6 +208,7 @@ Download the font of the language that you want to use in Obsidian and add it to
 ## Hosting behind a reverse proxy
 
 If you wish to do that **please make sure you are securing it in some way!**. You also need to ensure **websocket** support is enabled.
+Even if you can set auth to reach the container, it's always a good practice to secure auth to the higher level. So it's better to set password auth via the reverse proxy rather than here.
 
 ### Example nginx configuration
 
@@ -249,7 +275,7 @@ Create a proxy host in NPM pointing to the "obsidian-remote:8080" container, cho
 
 ## Updating Obsidian
 
-By default obsidian will update itself in the container. If you recreate the container you will have to do the update again. This repo will be updated periodically to keep up with the latest version of Obsidian.
+When creating the container it download the latest version of obsidian.
 
 ## Building locally
 
@@ -275,9 +301,6 @@ docker run --rm -it `
 
 ## Copy/Paste From External Source
 
-Click on the circle to the left side of your browser window. In there you will find a textbox for updating the remote clipboard or copying from it.
-
-![image](https://user-images.githubusercontent.com/1399443/202805847-a87e2c7c-a5c6-4dea-bbae-4b25b4b5866a.png)
-
+Open the KasmVNC menu on the middle right and select clipboard
 
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ cp .env.example .env
 
 Now edit your .env file and fill your Nextcloud credentials and informations.
 
+When starting your docker container, you'll have to mention en env-file
+
+```PowerShell
+docker run -d `
+  -v D:/ob/vaults:/vaults `
+  -v D:/ob/config:/config `
+  -p 8080:8080 `
+  --env-file .env `
+  ghcr.io/sytone/obsidian-remote:latest
+```
+
 ### Trigger Sync
 
 The synchronization with Nextcloud is not automated because Obsidian frequently performs file save, which could result in frequent and potentially unnecessary synchronizations. To avoid network overload and minimize unnecessary traffic, the synchronization with Nextcloud is left to the user's discretion and must be done manually.

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -6,13 +6,15 @@
                 <command>sudo /usr/bin/obsidian --no-sandbox</command>
             </action>
         </item>
+        <item label="Sync Nextcloud" icon="/usr/share/icons/hicolor/48x48/apps/Nextcloud.png">
+            <action name="Execute">
+                <command>xterm -e "bash /defaults/nextcloud.sh"</command>
+            </action>
+        </item>
         <item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm">
             <action name="Execute">
                 <command>/usr/bin/xterm</command>
             </action>
-        </item>
-        <item label="Reload OB">
-            <action name="Reconfigure" />
         </item>
     </menu>
 </openbox_menu>

--- a/root/defaults/nextcloud.sh
+++ b/root/defaults/nextcloud.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/with-contenv bash
+if [[ -z "${NC_PASS}" ]]; then
+  echo "NEXTCLOUD VARIABLES NOT SET"
+  echo "Please fill the env file"
+  sleep 100
+  exit 1
+fi
+
+echo "Sync NC file in progress"
+sync=$(/usr/bin/nextcloudcmd --path ${NC_PATH} /vaults https://${NC_USER}:${NC_PASS}@${NC_HOST})
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+  echo "SYNC FAILED"
+  echo $sync
+  echo $exit_code
+  echo "SYNC FAILED"
+  sleep 100
+else
+  echo "Sync complete"
+  sleep 5
+fi

--- a/root/defaults/startwm.sh
+++ b/root/defaults/startwm.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-/startpulse.sh &
-/usr/bin/openbox-session > /dev/null 2>&1


### PR DESCRIPTION
- Update Debian to Bookworm
- Nextcloud sync feature can now sync your MD files with your Nextcloud instance
  - Env-file contains the credentials for Nextcloud
  - Sync trigger have to be done manually (right click on the desktop)
- Dockerfile now download the latest release directly
- Update Readme regarding the clipboard menu