### PR TITLE
Update Obsidian to 1.5.3

### DIFF
--- a/dockerfile.amd64
+++ b/dockerfile.amd64
@@ -7,7 +7,7 @@ RUN echo "**** install packages ****" && \
     apt-get autoclean && rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
 
 # Set version label
-ARG OBSIDIAN_VERSION=1.3.5
+ARG OBSIDIAN_VERSION=1.5.3
 
 # Download and install Obsidian
 RUN echo "**** download obsidian ****" && \


### PR DESCRIPTION
Briefly tested by building and running locally.

This resolves the error/warning message printed by Obsidian on startup that the current installer version is 1.3.5 and is out of date and needs to be updated.

Only did `dockerfile.amd64` as it looks like that's the one that's getting built and pushed atm.