### PR TITLE
Fix Dockerfile file name in GH actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,22 +55,10 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: dockerfile.amd64
+          file: Dockerfile.amd64
           platforms: linux/amd64
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:latest
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:buildcache_amd64
           cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:buildcache_amd64,mode=max
-
-#      - name: Build and push Docker images
-#        uses: docker/build-push-action@v5
-        #with:
-          #context: .
-          #file: dockerfile.arm64
-          #platforms: linux/arm64
-          #push: true
-          #tags: ${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:arm64
-          #labels: ${{ steps.meta.outputs.labels }}
-          #cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:buildcache_arm64
-          #cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/obsidian-remote:buildcache_arm64,mode=max          


### PR DESCRIPTION
In https://github.com/sytone/obsidian-remote/commit/fbb7a1399b61268df031c94042fbdd2fd460914f, `dockerfile.amd64` got renamed to `Dockerfile.amd64`. This [breaks the GH action](https://github.com/sytone/obsidian-remote/actions/runs/11449162959/job/31854163215) to build the Docker image, since the configs still expect the original file name.

(This PR also removes the commented-out configs for `arm64` since the corresponding Dockerfile was previously removed.)