### PR TITLE
Debian Bookworm Upgrade [URGENT]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbullseye
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbookworm
 
 LABEL maintainer="github@sytone.com" \
       org.opencontainers.image.authors="github@sytone.com" \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbullseye
+FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbookworm
 
 LABEL maintainer="github@sytone.com" \
       org.opencontainers.image.authors="github@sytone.com" \


### PR DESCRIPTION
As I explained [here](https://github.com/sytone/obsidian-remote/pull/77#issuecomment-2496047797) the image fails to build since there is no debianbullseye tag published anymore. For this to even build this needs to be changed to debianbookworm. I tested it myself and everything works.