### PR TITLE
Update README.md arm64 image tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ docker run -d `
   -v D:/ob/vaults:/vaults `
   -v D:/ob/config:/config `
   -p 8080:8080 `
-  sytone/obsidian-remote:latest
+  sytone/obsidian-remote:arm64
 ```
 
 ### Linux bash paths


### PR DESCRIPTION
When running docker pull for arm64 image (as per documentation), error occurs:
```
docker pull sytone/obsidian-remote:latest
latest: Pulling from sytone/obsidian-remote
no matching manifest for linux/arm64/v8 in the manifest list entries
```
Image tag should be changed to `arm64`, which is present in registry:
```
docker pull sytone/obsidian-remote:arm64
arm64: Pulling from sytone/obsidian-remote
Digest: sha256:99d0324ac9fd1f51844499fff562f73a855b7e40e51eacde59e401067ba9edb4
Status: Image is up to date for sytone/obsidian-remote:arm64
docker.io/sytone/obsidian-remote:arm64
```